### PR TITLE
Linkable headers

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -50,6 +50,27 @@ h1 a:hover, h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover {
     text-decoration:underline;
 }
 
+.header-link {
+  position: relative;
+  left: 0.5em;
+  opacity: 0;
+  font-size: 0.8em;
+  text-align: top;
+  color: #999;
+}
+
+.header-link:before {
+  content: "¶";
+}
+
+h1:hover .header-link,
+h2:hover .header-link,
+h3:hover .header-link,
+h4:hover .header-link,
+h5:hover .header-link {
+  opacity: 1;
+}
+
 .permalink {
     display:none;
 }

--- a/js/site.js
+++ b/js/site.js
@@ -1,8 +1,12 @@
 var headers = document.querySelectorAll('h2, h3, h4');
 
 for (var i = 0; i < headers.length; i++) {
+    // set header id from its content
     headers[i].id = headers[i].innerHTML
         .replace(/^\s+|\s+$/g, '')
         .toLowerCase()
         .replace(/[^\w]/g, '-');
+
+    // turn header into anchor
+    headers[i].innerHTML = headers[i].innerHTML + '<a href="#' + headers[i].id + '" class="header-link"></a>';
 }


### PR DESCRIPTION
I made something! Now people can get clickable anchor links when hovering headings. This makes it easy to link to mapschool parts.

Unfortunately the ¶ character looks a bit weird as it "shifts" under the text baseline. I would have preferred the Unicode LINK SYMBOL, but that is not widely supported in fonts.

Not sure if h1 should be left out in the js, the pages use h1 tags where linkability would be nice. I would rather add h1 to the id and anchor generation but was not sure.

Not sure if h6 should be added in both js and all the css rules.